### PR TITLE
Fix broken hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,4 +510,4 @@ Swift Style Guide
 
 ## 라이센스
 
-본 스타일 가이드 문서는 CC-By 3.0 라이센스를 따릅니다. 자세한 내용은 [http://creativecommons.org/licenses/by/3.0/][http://creativecommons.org/licenses/by/3.0/] 링크를 참조해주세요.
+본 스타일 가이드 문서는 CC-By 3.0 라이센스를 따릅니다. 자세한 내용은 [http://creativecommons.org/licenses/by/3.0/](http://creativecommons.org/licenses/by/3.0/) 링크를 참조해주세요.


### PR DESCRIPTION
Fix broken link due to wrong use of markdown hyperlink syntax.
